### PR TITLE
Adds deploy.sh (one-line install script) and other tools

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,57 @@
+# =============================================================================
+# ByteGrader Configuration
+# =============================================================================
+# 1. Edit this file
+# 2. Run: sudo bash deploy.sh
+# All settings live here — no interactive prompts.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Domain Settings
+# -----------------------------------------------------------------------------
+
+# Your root domain (redirects to GitHub)
+domain: bytegrader.com
+
+# Course subdomain — autograder will be at https://<subdomain>.<domain>/
+subdomain: esp32-iot
+
+# Email for Let's Encrypt SSL certificate notifications
+ssl_email: you@example.com
+
+# -----------------------------------------------------------------------------
+# Security
+# -----------------------------------------------------------------------------
+
+# IP whitelist: IPv4/IPv6 addresses or CIDR blocks allowed to connect.
+# Leave empty ([]) to allow all IPs.
+# Example: ["203.0.113.5", "192.168.1.0/24"]
+ip_whitelist: []
+
+# API keys for client authentication.
+# Leave empty ([]) to disable API key requirement.
+# Example: ["my-secret-key"]
+api_keys: []
+
+# -----------------------------------------------------------------------------
+# Grader Images
+# -----------------------------------------------------------------------------
+# Maps assignment names (used as ?assignment=<name>) to Docker image tags.
+# Images must be pre-built and available on the server.
+grader_images:
+  make-c-add: bytegrader-make-c-add:latest
+  test-stub:  bytegrader-test-stub:latest
+  test-delay: bytegrader-test-delay:latest
+
+# -----------------------------------------------------------------------------
+# Server Settings
+# -----------------------------------------------------------------------------
+
+# Port the ByteGrader server listens on (inside Docker)
+app_port: 8080
+
+# Directory where deployed app files live
+app_dir: /home/bytegrader/app
+
+# System user that owns and runs ByteGrader
+bytegrader_user: bytegrader

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# =============================================================================
+# ByteGrader Unified Deployment Script
+# =============================================================================
+# Replaces setup-server.sh, deploy/deploy.sh, and setup-ssl.sh.
+# Reads all configuration from config.yaml — no interactive prompts.
+#
+# Usage:
+#   sudo bash deploy.sh [--skip-ssl] [--skip-build]
+#
+# Options:
+#   --skip-ssl      Skip SSL certificate generation (useful for local testing)
+#   --skip-build    Skip Docker image builds (use existing images)
+# =============================================================================
+
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+info()    { echo -e "${BLUE}ℹ${NC}  $*"; }
+success() { echo -e "${GREEN}✅${NC} $*"; }
+warn()    { echo -e "${YELLOW}⚠${NC}  $*"; }
+die()     { echo -e "${RED}❌ ERROR:${NC} $*" >&2; exit 1; }
+header()  { echo -e "\n${BOLD}━━━ $* ━━━${NC}"; }
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+SKIP_SSL=false
+SKIP_BUILD=false
+for arg in "$@"; do
+  case $arg in
+    --skip-ssl)   SKIP_SSL=true ;;
+    --skip-build) SKIP_BUILD=true ;;
+    *) die "Unknown argument: $arg" ;;
+  esac
+done
+
+[[ $EUID -ne 0 ]] && die "Run as root: sudo bash deploy.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="$SCRIPT_DIR/config.yaml"
+[[ -f "$CONFIG" ]] || die "config.yaml not found at $SCRIPT_DIR"
+
+# ── Step 1: Dependencies ──────────────────────────────────────────────────────
+header "Step 1 — Installing Dependencies"
+
+apt-get update -qq
+apt-get install -y -qq \
+  ca-certificates curl wget git vim htop ufw \
+  nginx certbot python3-certbot-nginx python3-yaml \
+  > /dev/null 2>&1
+success "System packages ready"
+
+if ! command -v docker &>/dev/null; then
+  info "Installing Docker..."
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc 2>/dev/null
+  chmod a+r /etc/apt/keyrings/docker.asc
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+     https://download.docker.com/linux/ubuntu \
+     $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+  apt-get update -qq
+  apt-get install -y -qq \
+    docker-ce docker-ce-cli containerd.io \
+    docker-buildx-plugin docker-compose-plugin \
+    > /dev/null 2>&1
+  success "Docker installed"
+else
+  success "Docker already installed"
+fi
+
+# ── Step 2: Read config ───────────────────────────────────────────────────────
+header "Step 2 — Reading Configuration"
+
+cfg() {
+  python3 - "$1" <<'PYEOF'
+import sys, yaml, os
+os.chdir(os.path.dirname(os.path.abspath("config.yaml")))
+key = sys.argv[1]
+with open("config.yaml") as f:
+    d = yaml.safe_load(f)
+val = d.get(key, "")
+if isinstance(val, list):
+    print("\n".join(str(v) for v in val if v))
+elif val is None:
+    print("")
+else:
+    print(str(val))
+PYEOF
+}
+
+cd "$SCRIPT_DIR"
+
+DOMAIN=$(cfg "domain");           [[ -z "$DOMAIN" ]]      && die "domain is required in config.yaml"
+SUBDOMAIN=$(cfg "subdomain");     [[ -z "$SUBDOMAIN" ]]   && die "subdomain is required in config.yaml"
+SSL_EMAIL=$(cfg "ssl_email");     [[ -z "$SSL_EMAIL" ]]   && die "ssl_email is required in config.yaml"
+[[ "$SSL_EMAIL" == "you@example.com" ]] && die "Please set a real ssl_email in config.yaml"
+
+FULL_DOMAIN="${SUBDOMAIN}.${DOMAIN}"
+APP_DIR=$(cfg "app_dir");         APP_DIR="${APP_DIR:-/home/bytegrader/app}"
+BG_USER=$(cfg "bytegrader_user"); BG_USER="${BG_USER:-bytegrader}"
+APP_PORT=$(cfg "app_port");       APP_PORT="${APP_PORT:-8080}"
+
+mapfile -t API_KEY_ARRAY < <(cfg "api_keys")
+API_KEYS_CSV=$(IFS=,; echo "${API_KEY_ARRAY[*]:-}")
+PRIMARY_API_KEY="${API_KEY_ARRAY[0]:-}"
+
+mapfile -t IP_WHITELIST < <(cfg "ip_whitelist")
+
+info "Domain:       $FULL_DOMAIN"
+info "App dir:      $APP_DIR"
+info "User:         $BG_USER"
+info "API keys:     ${#API_KEY_ARRAY[@]} configured"
+info "IP whitelist: ${#IP_WHITELIST[@]} entries (0 = open)"
+
+# ── Step 3: System user ───────────────────────────────────────────────────────
+header "Step 3 — System User"
+
+if ! id "$BG_USER" &>/dev/null; then
+  adduser --disabled-password --gecos "" "$BG_USER"
+  success "Created user: $BG_USER"
+else
+  success "User $BG_USER already exists"
+fi
+usermod -aG docker "$BG_USER"
+
+if [[ -f /root/.ssh/authorized_keys ]]; then
+  mkdir -p "/home/$BG_USER/.ssh"
+  cp /root/.ssh/authorized_keys "/home/$BG_USER/.ssh/"
+  chown -R "$BG_USER:$BG_USER" "/home/$BG_USER/.ssh"
+  chmod 700 "/home/$BG_USER/.ssh"
+  chmod 600 "/home/$BG_USER/.ssh/authorized_keys"
+fi
+
+# ── Step 4: Environment file ──────────────────────────────────────────────────
+header "Step 4 — Environment File"
+
+ENV_FILE="/home/$BG_USER/.bytegrader_env"
+cat > "$ENV_FILE" <<EOF
+# Generated by deploy.sh — edit config.yaml and re-run to update
+BYTEGRADER_DOMAIN=${DOMAIN}
+BYTEGRADER_SUBDOMAIN=${SUBDOMAIN}
+BYTEGRADER_FULL_DOMAIN=${FULL_DOMAIN}
+BYTEGRADER_SSL_EMAIL=${SSL_EMAIL}
+BYTEGRADER_API_KEYS=${API_KEYS_CSV}
+BYTEGRADER_APP_PORT=${APP_PORT}
+BYTEGRADER_APP_DIR=${APP_DIR}
+BYTEGRADER_USER=${BG_USER}
+BYTEGRADER_REQUIRE_API_KEY=$([[ -n "$API_KEYS_CSV" ]] && echo "true" || echo "false")
+BYTEGRADER_VALID_API_KEYS=${API_KEYS_CSV}
+EOF
+chown "$BG_USER:$BG_USER" "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+success "Environment file written"
+
+# ── Step 5: Deploy app ────────────────────────────────────────────────────────
+header "Step 5 — Deploying Application"
+
+mkdir -p "$APP_DIR"
+chown "$BG_USER:$BG_USER" "$APP_DIR"
+
+if [[ "$SKIP_BUILD" == false ]]; then
+  info "Building and deploying containers..."
+  sudo -u "$BG_USER" bash "$SCRIPT_DIR/deploy/deploy.sh" "$APP_DIR"
+
+  # Patch docker-compose.yaml for Blue/Green support
+  COMPOSE_FILE="$APP_DIR/docker-compose.yaml"
+  if [[ -f "$COMPOSE_FILE" ]]; then
+    # Allow port to be overridden via APP_PORT env var
+    sed -i 's|"127.0.0.1:8080:8080"|"127.0.0.1:${APP_PORT:-8080}:8080"|g' "$COMPOSE_FILE"
+    # Allow container name to be overridden via CONTAINER_NAME env var
+    sed -i 's|container_name: bytegrader-.*|container_name: ${CONTAINER_NAME:-bytegrader-app}|g' "$COMPOSE_FILE"
+    success "Patched docker-compose.yaml for Blue/Green support"
+  fi
+else
+  warn "--skip-build: bringing up existing containers"
+  cd "$APP_DIR" && sudo -u "$BG_USER" docker compose up -d 2>/dev/null || true
+fi
+
+# Wait for healthy
+info "Waiting for service..."
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${APP_PORT}/health" &>/dev/null; then
+    success "App is healthy"
+    break
+  fi
+  sleep 2
+  [[ $i -eq 30 ]] && die "App did not become healthy. Check: cd $APP_DIR && docker compose logs"
+done
+
+# ── Step 6: nginx ─────────────────────────────────────────────────────────────
+header "Step 6 — Configuring Nginx"
+
+# Build IP restriction block
+IP_BLOCK=""
+if [[ ${#IP_WHITELIST[@]} -gt 0 && -n "${IP_WHITELIST[0]}" ]]; then
+  for ip in "${IP_WHITELIST[@]}"; do
+    [[ -n "$ip" ]] && IP_BLOCK+="        allow ${ip};\n"
+  done
+  IP_BLOCK+="        deny all;\n"
+fi
+
+mkdir -p /var/www/html
+
+cat > /etc/nginx/sites-available/bytegrader <<NGINX
+# ByteGrader nginx config — generated by deploy.sh
+
+# Redirect root domain to GitHub
+server {
+    listen 80;
+    server_name ${DOMAIN} www.${DOMAIN};
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / { return 301 https://github.com/ShawnHymel/bytegrader; }
+}
+
+# Course API — HTTP to HTTPS redirect
+server {
+    listen 80;
+    server_name ${FULL_DOMAIN};
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / { return 301 https://\$server_name\$request_uri; }
+}
+
+# Course API — HTTPS
+server {
+    listen 443 ssl http2;
+    server_name ${FULL_DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${FULL_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${FULL_DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+    location / {
+$(printf '%b' "$IP_BLOCK")
+        # CORS — allow both localhost and 127.0.0.1 for local dev tools
+        proxy_hide_header Access-Control-Allow-Origin;
+        set \$cors_origin "";
+        if (\$http_origin ~* "^https?://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?\$") {
+            set \$cors_origin \$http_origin;
+        }
+        add_header Access-Control-Allow-Origin \$cors_origin always;
+        add_header Access-Control-Allow-Headers "X-API-Key, X-Username, Content-Type" always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+
+        if (\$request_method = OPTIONS) { return 204; }
+
+        proxy_pass         http://localhost:${APP_PORT};
+        proxy_set_header   Host              \$host;
+        proxy_set_header   X-Real-IP         \$remote_addr;
+        proxy_set_header   X-Forwarded-For   \$proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto \$scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 10s;
+        client_max_body_size 100M;
+    }
+}
+NGINX
+
+ln -sf /etc/nginx/sites-available/bytegrader /etc/nginx/sites-enabled/bytegrader
+rm -f /etc/nginx/sites-enabled/default
+
+# Test without SSL block if cert doesn't exist yet
+if [[ ! -f "/etc/letsencrypt/live/${FULL_DOMAIN}/fullchain.pem" ]]; then
+  # Write HTTP-only config for initial certbot run
+  cat > /etc/nginx/sites-available/bytegrader <<NGINX_HTTP
+# ByteGrader nginx config (HTTP only — run deploy.sh again after DNS propagates for SSL)
+
+server {
+    listen 80;
+    server_name ${DOMAIN} www.${DOMAIN};
+    location / { return 301 https://github.com/ShawnHymel/bytegrader; }
+}
+
+server {
+    listen 80;
+    server_name ${FULL_DOMAIN};
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / {
+        proxy_pass http://localhost:${APP_PORT};
+        proxy_set_header Host \$host;
+        proxy_read_timeout 300s;
+        client_max_body_size 100M;
+    }
+}
+NGINX_HTTP
+fi
+
+nginx -t && systemctl reload nginx
+success "Nginx configured"
+
+# ── Step 7: Firewall ──────────────────────────────────────────────────────────
+header "Step 7 — Firewall"
+
+ufw allow OpenSSH    > /dev/null 2>&1
+ufw allow 'Nginx Full' > /dev/null 2>&1
+ufw --force enable   > /dev/null 2>&1
+success "Firewall: SSH + HTTP/HTTPS open"
+
+# ── Step 8: SSL ───────────────────────────────────────────────────────────────
+if [[ "$SKIP_SSL" == false ]]; then
+  header "Step 8 — SSL Certificate"
+
+  SERVER_IP=$(curl -4 -sf https://ifconfig.me 2>/dev/null || true)
+  RESOLVED_IP=$(getent hosts "$FULL_DOMAIN" 2>/dev/null | awk '{print $1}' || true)
+
+  if [[ "$SERVER_IP" != "$RESOLVED_IP" ]]; then
+    warn "DNS not ready: server is $SERVER_IP but $FULL_DOMAIN resolves to ${RESOLVED_IP:-nothing}"
+    warn "Set your A record and re-run: sudo bash deploy.sh --skip-build"
+    SKIP_SSL=true
+  else
+    certbot certonly \
+      --nginx \
+      --non-interactive \
+      --agree-tos \
+      -m "$SSL_EMAIL" \
+      -d "$FULL_DOMAIN" || { warn "certbot failed — re-run after DNS propagates"; SKIP_SSL=true; }
+
+    if [[ "$SKIP_SSL" == false ]]; then
+      # Now write the full HTTPS config
+      cat > /etc/nginx/sites-available/bytegrader <<NGINX_FULL
+# ByteGrader nginx config — generated by deploy.sh
+
+server {
+    listen 80;
+    server_name ${DOMAIN} www.${DOMAIN};
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / { return 301 https://github.com/ShawnHymel/bytegrader; }
+}
+
+server {
+    listen 80;
+    server_name ${FULL_DOMAIN};
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / { return 301 https://\$server_name\$request_uri; }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name ${FULL_DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${FULL_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${FULL_DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+    location / {
+$(printf '%b' "$IP_BLOCK")
+        proxy_hide_header Access-Control-Allow-Origin;
+        set \$cors_origin "";
+        if (\$http_origin ~* "^https?://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?\$") {
+            set \$cors_origin \$http_origin;
+        }
+        add_header Access-Control-Allow-Origin \$cors_origin always;
+        add_header Access-Control-Allow-Headers "X-API-Key, X-Username, Content-Type" always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+
+        if (\$request_method = OPTIONS) { return 204; }
+
+        proxy_pass         http://localhost:${APP_PORT};
+        proxy_set_header   Host              \$host;
+        proxy_set_header   X-Real-IP         \$remote_addr;
+        proxy_set_header   X-Forwarded-For   \$proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto \$scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 10s;
+        client_max_body_size 100M;
+    }
+}
+NGINX_FULL
+      nginx -t && systemctl reload nginx
+      success "HTTPS enabled for https://$FULL_DOMAIN"
+    fi
+  fi
+else
+  info "Skipping SSL (--skip-ssl)"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+header "Deployment Complete"
+
+LOCAL=$(curl -sf "http://localhost:${APP_PORT}/health" || echo "FAILED")
+echo ""
+echo -e "  ${GREEN}Local health:${NC}  $LOCAL"
+if [[ "$SKIP_SSL" == false ]]; then
+  REMOTE=$(curl -sf "https://${FULL_DOMAIN}/health" 2>/dev/null || echo "not yet reachable")
+  echo -e "  ${GREEN}Remote health:${NC} $REMOTE"
+fi
+echo ""
+echo -e "  ${BOLD}Endpoint:${NC}  https://${FULL_DOMAIN}"
+echo -e "  ${BOLD}Logs:${NC}      cd $APP_DIR && docker compose logs -f"
+echo -e "  ${BOLD}Update:${NC}    sudo bash update.sh"
+echo ""
+success "ByteGrader is live!"

--- a/tools/index.html
+++ b/tools/index.html
@@ -1,0 +1,605 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ByteGrader — Internal Test Tool</title>
+  <style>
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --border: #2e3147;
+      --accent: #4f8ef7;
+      --green: #3ddc84;
+      --red: #ff5252;
+      --yellow: #ffd740;
+      --text: #e0e3f0;
+      --muted: #6b7280;
+      --mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 28px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    header h1 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    header .badge {
+      background: #2a2d3e;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      font-size: 0.7rem;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-family: var(--mono);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 360px 1fr;
+      gap: 20px;
+      max-width: 1400px;
+      margin: 0 auto;
+    }
+
+    @media (max-width: 800px) {
+      .layout { grid-template-columns: 1fr; }
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .card-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 14px 16px 10px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .card-body { padding: 16px; }
+
+    label {
+      display: block;
+      font-size: 0.8rem;
+      color: var(--muted);
+      margin-bottom: 5px;
+      margin-top: 14px;
+    }
+    label:first-child { margin-top: 0; }
+
+    input[type="text"], input[type="url"], select {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 0.875rem;
+      font-family: var(--mono);
+      padding: 8px 10px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    input:focus, select:focus { border-color: var(--accent); }
+
+    .file-drop {
+      border: 1.5px dashed var(--border);
+      border-radius: 8px;
+      padding: 20px;
+      text-align: center;
+      cursor: pointer;
+      transition: border-color 0.2s, background 0.2s;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+    .file-drop:hover, .file-drop.drag-over {
+      border-color: var(--accent);
+      background: rgba(79,142,247,0.04);
+      color: var(--accent);
+    }
+    .file-drop.has-file {
+      border-color: var(--green);
+      color: var(--green);
+    }
+    .file-drop input { display: none; }
+
+    .btn {
+      display: block;
+      width: 100%;
+      margin-top: 16px;
+      padding: 10px;
+      border-radius: 7px;
+      border: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s, transform 0.1s;
+    }
+    .btn:active { transform: scale(0.98); }
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn-secondary { background: var(--border); color: var(--text); margin-top: 8px; }
+
+    /* Status panel */
+    .status-bar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      font-size: 0.8rem;
+      border-bottom: 1px solid var(--border);
+      min-height: 40px;
+    }
+
+    .dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .dot-idle    { background: var(--muted); }
+    .dot-running { background: var(--yellow); animation: pulse 1s infinite; }
+    .dot-ok      { background: var(--green); }
+    .dot-err     { background: var(--red); }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+
+    .log-area {
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      line-height: 1.6;
+      padding: 14px 16px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      min-height: 420px;
+      max-height: 65vh;
+      overflow-y: auto;
+      color: #9ca3af;
+    }
+
+    .log-area:empty::before {
+      content: 'Output will appear here after submission...';
+      color: var(--muted);
+      font-style: italic;
+    }
+
+    .log-area .log-info  { color: #9ca3af; }
+    .log-area .log-ok    { color: var(--green); }
+    .log-area .log-err   { color: var(--red); }
+    .log-area .log-warn  { color: var(--yellow); }
+    .log-area .log-key   { color: var(--accent); }
+    .log-area .log-val   { color: #c4b5fd; }
+
+    .result-box {
+      margin: 12px 16px;
+      padding: 14px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-family: var(--mono);
+      font-size: 0.8rem;
+    }
+    .result-box.pass { border-color: var(--green); }
+    .result-box.fail { border-color: var(--red); }
+
+    .grade-badge {
+      display: inline-block;
+      font-size: 1.4rem;
+      font-weight: 700;
+      font-family: var(--mono);
+      letter-spacing: -0.02em;
+    }
+    .grade-badge.pass { color: var(--green); }
+    .grade-badge.fail { color: var(--red); }
+
+    .meta-row {
+      display: flex;
+      gap: 20px;
+      flex-wrap: wrap;
+      margin-top: 8px;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+    .meta-row span { font-family: var(--mono); color: var(--text); }
+  </style>
+</head>
+<body>
+
+<header>
+  <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+    <rect width="28" height="28" rx="6" fill="#4f8ef7" opacity="0.15"/>
+    <path d="M7 14l5 5 9-9" stroke="#4f8ef7" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+  <h1>ByteGrader</h1>
+  <span class="badge">Internal Test Tool</span>
+</header>
+
+<div class="layout">
+
+  <!-- ── Left: Config panel ── -->
+  <div>
+    <div class="card">
+      <div class="card-title">Submission Config</div>
+      <div class="card-body">
+
+        <label for="serverUrl">Server URL</label>
+        <input type="url" id="serverUrl" placeholder="https://esp32-iot.bytegrader.com" />
+
+        <label for="apiKey">API Key</label>
+        <input type="text" id="apiKey" placeholder="leave blank if not required" />
+
+        <label for="username">Username</label>
+        <input type="text" id="username" value="test-user" />
+
+        <label for="assignment">Assignment</label>
+        <input type="text" id="assignment" value="make-c-add" placeholder="assignment name" />
+
+        <label style="margin-top:16px">ZIP File</label>
+        <div class="file-drop" id="dropZone">
+          <input type="file" id="fileInput" accept=".zip" />
+          <div id="dropLabel">
+            📦 Drop ZIP here or <u>click to browse</u>
+          </div>
+        </div>
+
+        <button class="btn btn-primary" id="submitBtn" disabled>
+          Submit for Grading
+        </button>
+        <button class="btn btn-secondary" id="clearBtn">
+          Clear Output
+        </button>
+
+      </div>
+    </div>
+
+    <!-- Quick-links -->
+    <div class="card" style="margin-top:16px">
+      <div class="card-title">Quick Checks</div>
+      <div class="card-body" style="display:flex;flex-direction:column;gap:8px">
+        <button class="btn btn-secondary" id="healthBtn">🏥 /health</button>
+        <button class="btn btn-secondary" id="queueBtn">📋 /queue</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Right: Output panel ── -->
+  <div class="card" style="display:flex;flex-direction:column">
+    <div class="status-bar">
+      <div class="dot dot-idle" id="statusDot"></div>
+      <span id="statusText">Idle</span>
+    </div>
+
+    <div id="resultBox" style="display:none"></div>
+    <div class="log-area" id="logArea"></div>
+  </div>
+
+</div>
+
+<script>
+// ── State ──────────────────────────────────────────────────────────────────
+let selectedFile = null;
+let pollTimer = null;
+
+// ── DOM refs ───────────────────────────────────────────────────────────────
+const serverUrl  = document.getElementById('serverUrl');
+const apiKey     = document.getElementById('apiKey');
+const username   = document.getElementById('username');
+const assignment = document.getElementById('assignment');
+const fileInput  = document.getElementById('fileInput');
+const dropZone   = document.getElementById('dropZone');
+const dropLabel  = document.getElementById('dropLabel');
+const submitBtn  = document.getElementById('submitBtn');
+const clearBtn   = document.getElementById('clearBtn');
+const healthBtn  = document.getElementById('healthBtn');
+const queueBtn   = document.getElementById('queueBtn');
+const logArea    = document.getElementById('logArea');
+const statusDot  = document.getElementById('statusDot');
+const statusText = document.getElementById('statusText');
+const resultBox  = document.getElementById('resultBox');
+
+// ── Persist config in localStorage ────────────────────────────────────────
+function loadPrefs() {
+  serverUrl.value  = localStorage.getItem('bg_url')  || '';
+  apiKey.value     = localStorage.getItem('bg_key')  || '';
+  username.value   = localStorage.getItem('bg_user') || 'test-user';
+  assignment.value = localStorage.getItem('bg_asgn') || 'make-c-add';
+}
+function savePrefs() {
+  localStorage.setItem('bg_url',  serverUrl.value);
+  localStorage.setItem('bg_key',  apiKey.value);
+  localStorage.setItem('bg_user', username.value);
+  localStorage.setItem('bg_asgn', assignment.value);
+}
+[serverUrl, apiKey, username, assignment].forEach(el =>
+  el.addEventListener('input', savePrefs)
+);
+loadPrefs();
+
+// ── File handling ──────────────────────────────────────────────────────────
+dropZone.addEventListener('click', () => fileInput.click());
+fileInput.addEventListener('change', () => setFile(fileInput.files[0]));
+
+dropZone.addEventListener('dragover', e => {
+  e.preventDefault();
+  dropZone.classList.add('drag-over');
+});
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('drag-over'));
+dropZone.addEventListener('drop', e => {
+  e.preventDefault();
+  dropZone.classList.remove('drag-over');
+  const f = e.dataTransfer.files[0];
+  if (f) setFile(f);
+});
+
+function setFile(f) {
+  if (!f || !f.name.endsWith('.zip')) {
+    setStatus('error', 'Please select a .zip file');
+    return;
+  }
+  selectedFile = f;
+  dropZone.classList.add('has-file');
+  dropLabel.textContent = `📦 ${f.name} (${formatBytes(f.size)})`;
+  submitBtn.disabled = false;
+}
+
+function formatBytes(b) {
+  if (b < 1024) return b + ' B';
+  if (b < 1024*1024) return (b/1024).toFixed(1) + ' KB';
+  return (b/1024/1024).toFixed(2) + ' MB';
+}
+
+// ── Log helpers ────────────────────────────────────────────────────────────
+function log(msg, cls = 'log-info') {
+  const line = document.createElement('div');
+  line.className = cls;
+  line.textContent = msg;
+  logArea.appendChild(line);
+  logArea.scrollTop = logArea.scrollHeight;
+}
+
+function logJson(obj, cls = 'log-info') {
+  try {
+    const lines = JSON.stringify(obj, null, 2).split('\n');
+    lines.forEach(l => {
+      const m = l.match(/^(\s*)("[\w_]+")(\s*:\s*)(.+)$/);
+      if (m) {
+        const el = document.createElement('div');
+        el.className = cls;
+        el.innerHTML =
+          m[1] +
+          `<span class="log-key">${m[2]}</span>` +
+          m[3] +
+          `<span class="log-val">${m[4]}</span>`;
+        logArea.appendChild(el);
+      } else {
+        log(l, cls);
+      }
+    });
+  } catch {
+    log(String(obj), cls);
+  }
+  logArea.scrollTop = logArea.scrollHeight;
+}
+
+function clearLog() {
+  logArea.innerHTML = '';
+  resultBox.style.display = 'none';
+}
+
+function setStatus(state, msg) {
+  statusText.textContent = msg;
+  statusDot.className = 'dot';
+  if (state === 'running') statusDot.classList.add('dot-running');
+  else if (state === 'ok')  statusDot.classList.add('dot-ok');
+  else if (state === 'error') statusDot.classList.add('dot-err');
+  else statusDot.classList.add('dot-idle');
+}
+
+// ── API helpers ────────────────────────────────────────────────────────────
+function baseUrl() {
+  return (serverUrl.value || '').replace(/\/$/, '');
+}
+
+function headers() {
+  const h = {};
+  if (username.value) h['X-Username'] = username.value;
+  if (apiKey.value)   h['X-API-Key']  = apiKey.value;
+  return h;
+}
+
+async function apiFetch(path, opts = {}) {
+  const res = await fetch(baseUrl() + path, {
+    headers: { ...headers(), ...opts.headers },
+    ...opts
+  });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { raw: text }; }
+  return { ok: res.ok, status: res.status, json };
+}
+
+// ── Submit ─────────────────────────────────────────────────────────────────
+submitBtn.addEventListener('click', async () => {
+  if (!selectedFile) return;
+  if (!baseUrl()) { setStatus('error', 'Set Server URL first'); return; }
+
+  submitBtn.disabled = true;
+  clearLog();
+  setStatus('running', 'Submitting...');
+
+  log(`▶  POST ${baseUrl()}/submit?assignment=${assignment.value}`);
+  log(`   file: ${selectedFile.name} (${formatBytes(selectedFile.size)})`);
+  log('');
+
+  const fd = new FormData();
+  fd.append('file', selectedFile, selectedFile.name);
+
+  let res;
+  try {
+    res = await fetch(
+      `${baseUrl()}/submit?assignment=${encodeURIComponent(assignment.value)}`,
+      { method: 'POST', headers: headers(), body: fd }
+    );
+  } catch (e) {
+    setStatus('error', 'Network error');
+    log('Network error: ' + e.message, 'log-err');
+    submitBtn.disabled = false;
+    return;
+  }
+
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { raw: text }; }
+
+  log(`◀  HTTP ${res.status}`, res.ok ? 'log-ok' : 'log-err');
+  logJson(json, res.ok ? 'log-ok' : 'log-err');
+
+  if (!res.ok || !json.job_id) {
+    setStatus('error', `Submission failed (HTTP ${res.status})`);
+    submitBtn.disabled = false;
+    return;
+  }
+
+  const jobId = json.job_id;
+  log('');
+  log(`⏳ Polling job: ${jobId}`, 'log-info');
+  pollStatus(jobId);
+});
+
+// ── Poll /status ───────────────────────────────────────────────────────────
+async function pollStatus(jobId) {
+  setStatus('running', `Grading job ${jobId.slice(0, 8)}…`);
+
+  const maxPolls = 120;
+  let polls = 0;
+
+  async function poll() {
+    if (polls++ >= maxPolls) {
+      setStatus('error', 'Timed out after 2 minutes');
+      log('Polling timed out.', 'log-err');
+      submitBtn.disabled = false;
+      return;
+    }
+
+    let res;
+    try {
+      res = await apiFetch(`/status/${jobId}`);
+    } catch (e) {
+      log('Poll error: ' + e.message, 'log-warn');
+      pollTimer = setTimeout(poll, 3000);
+      return;
+    }
+
+    const s = res.json?.job?.status ?? res.json?.status;
+
+    if (s === 'pending' || s === 'queued' || s === 'processing' || s === 'running') {
+      setStatus('running', `Status: ${s}…`);
+      pollTimer = setTimeout(poll, 3000);
+      return;
+    }
+
+    // Terminal state
+    log('');
+    log(`━━━ Result ━━━`, 'log-info');
+    logJson(res.json);
+
+    showResult(res.json);
+
+    if (s === 'completed') {
+      setStatus('ok', 'Grading complete');
+    } else {
+      setStatus('error', `Job ended with status: ${s}`);
+    }
+    submitBtn.disabled = false;
+  }
+
+  poll();
+}
+
+function showResult(data) {
+  resultBox.style.display = 'block';
+  const job     = data.job ?? data;
+  const jobId = (job.id || data.job_id || '').slice(0, 12);
+  const result  = job.result ?? {};
+  const score   = result.score ?? job.score ?? '—';
+  const maxScore = result.max_score ?? job.max_score ?? 100;
+  const passed  = result.passed ?? job.passed ?? (score !== '—' && parseFloat(score) >= parseFloat(maxScore));
+  const cls     = passed ? 'pass' : 'fail';
+
+  resultBox.className = `result-box ${cls}`;
+  resultBox.innerHTML = `
+    <div class="grade-badge ${cls}">${score} / ${maxScore}</div>
+    <div class="meta-row">
+      <div>Job <span>${(job.id || '').slice(0, 12)}…</span></div>
+      <div>Status <span>${job.status || '—'}</span></div>
+      ${data.duration_ms ? `<div>Duration <span>${data.duration_ms}ms</span></div>` : ''}
+    </div>
+    ${result.feedback ? `<div style="margin-top:10px;font-size:0.8rem;color:#9ca3af">${result.feedback}</div>` : ''}
+  `;
+}
+
+// ── Quick checks ───────────────────────────────────────────────────────────
+healthBtn.addEventListener('click', async () => {
+  if (!baseUrl()) { setStatus('error', 'Set Server URL first'); return; }
+  clearLog();
+  setStatus('running', 'Checking health…');
+  log(`▶  GET ${baseUrl()}/health`);
+  try {
+    const r = await apiFetch('/health');
+    log(`◀  HTTP ${r.status}`, r.ok ? 'log-ok' : 'log-err');
+    logJson(r.json);
+    setStatus(r.ok ? 'ok' : 'error', r.ok ? 'Healthy' : 'Unhealthy');
+  } catch(e) {
+    log('Error: ' + e.message, 'log-err');
+    setStatus('error', 'Network error');
+  }
+});
+
+queueBtn.addEventListener('click', async () => {
+  if (!baseUrl()) { setStatus('error', 'Set Server URL first'); return; }
+  clearLog();
+  setStatus('running', 'Fetching queue…');
+  log(`▶  GET ${baseUrl()}/queue`);
+  try {
+    const r = await apiFetch('/queue');
+    log(`◀  HTTP ${r.status}`, r.ok ? 'log-ok' : 'log-err');
+    logJson(r.json);
+    setStatus(r.ok ? 'ok' : 'error', `Queue fetched`);
+  } catch(e) {
+    log('Error: ' + e.message, 'log-err');
+    setStatus('error', 'Network error');
+  }
+});
+
+clearBtn.addEventListener('click', clearLog);
+</script>
+
+</body>
+</html>

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# =============================================================================
+# ByteGrader Update Script
+# =============================================================================
+# Zero-downtime Blue/Green container swap.
+# Auto-falls back to Stop-then-Start on low-memory hosts (e.g. Raspberry Pi).
+#
+# Usage:
+#   sudo bash update.sh [--force-stop-start] [--dry-run]
+# =============================================================================
+
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+info()    { echo -e "${BLUE}ℹ${NC}  $*"; }
+success() { echo -e "${GREEN}✅${NC} $*"; }
+warn()    { echo -e "${YELLOW}⚠${NC}  $*"; }
+die()     { echo -e "${RED}❌ ERROR:${NC} $*" >&2; exit 1; }
+header()  { echo -e "\n${BOLD}━━━ $* ━━━${NC}"; }
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+FORCE_STOP_START=false
+DRY_RUN=false
+for arg in "$@"; do
+  case $arg in
+    --force-stop-start) FORCE_STOP_START=true ;;
+    --dry-run)          DRY_RUN=true ;;
+    *) die "Unknown argument: $arg" ;;
+  esac
+done
+
+[[ $EUID -ne 0 ]] && die "Run as root: sudo bash update.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="$SCRIPT_DIR/config.yaml"
+[[ -f "$CONFIG" ]] || die "config.yaml not found. Run from the ByteGrader repo root."
+
+# ── YAML parser ───────────────────────────────────────────────────────────────
+cfg() {
+  python3 - "$1" <<'PYEOF'
+import sys, yaml
+key = sys.argv[1]
+with open("config.yaml") as f:
+    d = yaml.safe_load(f)
+val = d.get(key, "")
+print("" if val is None else str(val))
+PYEOF
+}
+
+cd "$SCRIPT_DIR"
+
+APP_DIR=$(cfg "app_dir");   APP_DIR="${APP_DIR:-/home/bytegrader/app}"
+APP_PORT=$(cfg "app_port"); APP_PORT="${APP_PORT:-8080}"
+FULL_DOMAIN="$(cfg subdomain).$(cfg domain)"
+NGINX_CONF="/etc/nginx/sites-available/bytegrader"
+
+# ── Slot helpers ──────────────────────────────────────────────────────────────
+SLOT_FILE="$APP_DIR/.active_slot"
+BLUE_PORT=8080
+GREEN_PORT=8081
+
+get_active_slot()   { [[ -f "$SLOT_FILE" ]] && cat "$SLOT_FILE" || echo "blue"; }
+get_inactive_slot() { [[ $(get_active_slot) == "blue" ]] && echo "green" || echo "blue"; }
+slot_port()         { [[ "$1" == "blue" ]] && echo $BLUE_PORT || echo $GREEN_PORT; }
+
+# ── RAM check ─────────────────────────────────────────────────────────────────
+MIN_FREE_MB=512
+check_ram() {
+  local free_mb
+  free_mb=$(awk '/MemAvailable/ {printf "%d", $2/1024}' /proc/meminfo)
+  info "Available RAM: ${free_mb}MB (need ${MIN_FREE_MB}MB for Blue/Green)"
+  [[ $free_mb -ge $MIN_FREE_MB ]]
+}
+
+# ── Health check ──────────────────────────────────────────────────────────────
+health_check() {
+  local port="$1" retries="${2:-20}" i
+  for i in $(seq 1 "$retries"); do
+    curl -sf "http://localhost:${port}/health" &>/dev/null && return 0
+    sleep 3
+  done
+  return 1
+}
+
+# ── nginx swap ────────────────────────────────────────────────────────────────
+swap_nginx() {
+  local new_port="$1"
+  sed -i "s|proxy_pass http://localhost:[0-9]*;|proxy_pass http://localhost:${new_port};|g" "$NGINX_CONF"
+  sed -i "s|proxy_pass http://127.0.0.1:[0-9]*;|proxy_pass http://127.0.0.1:${new_port};|g" "$NGINX_CONF"
+  nginx -t && systemctl reload nginx
+}
+
+# ── Pull ──────────────────────────────────────────────────────────────────────
+header "ByteGrader Update"
+
+info "Pulling latest from git..."
+[[ "$DRY_RUN" == false ]] && \
+  git -C "$SCRIPT_DIR" pull --ff-only 2>/dev/null || warn "git pull failed — using local version"
+
+info "Building updated Docker image..."
+if [[ "$DRY_RUN" == false ]]; then
+  APP_PORT=$BLUE_PORT CONTAINER_NAME="bytegrader-blue" \
+    docker compose --project-directory "$APP_DIR" --project-name "bytegrader-${BLUE_PORT}" \
+    build --pull 2>/dev/null || true
+fi
+
+# ── Strategy ──────────────────────────────────────────────────────────────────
+header "Selecting Update Strategy"
+
+USE_BLUEGREEN=false
+if [[ "$FORCE_STOP_START" == true ]]; then
+  warn "--force-stop-start: using Stop-then-Start"
+elif check_ram; then
+  USE_BLUEGREEN=true
+  info "Using Blue/Green zero-downtime swap"
+else
+  warn "Low RAM — falling back to Stop-then-Start"
+fi
+
+# ── Blue/Green ────────────────────────────────────────────────────────────────
+do_bluegreen() {
+  local active inactive active_port inactive_port
+  active=$(get_active_slot)
+  inactive=$(get_inactive_slot)
+  active_port=$(slot_port "$active")
+  inactive_port=$(slot_port "$inactive")
+
+  info "Active:  $active (port $active_port, container: bytegrader-$active)"
+  info "Staging: $inactive (port $inactive_port, container: bytegrader-$inactive)"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "[DRY RUN] Would start bytegrader-$inactive on port $inactive_port"
+    info "[DRY RUN] Would health check, swap nginx, stop bytegrader-$active"
+    return 0
+  fi
+
+  # Clean up any leftover container on the inactive port
+  docker rm -f "bytegrader-$inactive" 2>/dev/null || true
+
+  info "Starting bytegrader-$inactive on port $inactive_port..."
+  APP_PORT=$inactive_port CONTAINER_NAME="bytegrader-$inactive" \
+    docker compose \
+      --project-directory "$APP_DIR" \
+      --project-name "bytegrader-$inactive_port" \
+      up -d --build \
+    || die "Failed to start container on port $inactive_port"
+
+  info "Health checking port $inactive_port..."
+  if ! health_check "$inactive_port" 20; then
+    warn "Health check failed — rolling back"
+    APP_PORT=$inactive_port CONTAINER_NAME="bytegrader-$inactive" \
+      docker compose \
+        --project-directory "$APP_DIR" \
+        --project-name "bytegrader-$inactive_port" \
+        down 2>/dev/null || true
+    die "Update aborted. Check: cd $APP_DIR && docker compose logs"
+  fi
+  success "New container healthy on port $inactive_port"
+
+  info "Swapping nginx to port $inactive_port..."
+  swap_nginx "$inactive_port"
+  success "Nginx routing to $inactive (port $inactive_port)"
+
+  echo "$inactive" > "$SLOT_FILE"
+  sleep 3
+
+  info "Stopping old container (bytegrader-$active, port $active_port)..."
+  APP_PORT=$active_port CONTAINER_NAME="bytegrader-$active" \
+    docker compose \
+      --project-directory "$APP_DIR" \
+      --project-name "bytegrader-$active_port" \
+      down 2>/dev/null || true
+  success "Old container stopped"
+}
+
+# ── Stop-then-Start ───────────────────────────────────────────────────────────
+do_stop_start() {
+  if [[ "$DRY_RUN" == true ]]; then
+    info "[DRY RUN] Would stop then restart container"
+    return 0
+  fi
+
+  local active active_port
+  active=$(get_active_slot)
+  active_port=$(slot_port "$active")
+
+  info "Stopping current container..."
+  APP_PORT=$active_port CONTAINER_NAME="bytegrader-$active" \
+    docker compose --project-directory "$APP_DIR" \
+    --project-name "bytegrader-$active_port" down 2>/dev/null || true
+
+  info "Starting updated container..."
+  APP_PORT=$active_port CONTAINER_NAME="bytegrader-$active" \
+    docker compose --project-directory "$APP_DIR" \
+    --project-name "bytegrader-$active_port" up -d \
+    || die "Failed to start container"
+
+  health_check "$active_port" 20 || die "Container unhealthy. Check: cd $APP_DIR && docker compose logs"
+  success "Container is healthy"
+}
+
+# ── Run ───────────────────────────────────────────────────────────────────────
+header "Running Update"
+[[ "$USE_BLUEGREEN" == true ]] && do_bluegreen || do_stop_start
+
+# ── Verify ────────────────────────────────────────────────────────────────────
+header "Verification"
+
+ACTIVE_PORT=$(slot_port "$(get_active_slot)")
+LOCAL=$(curl -sf "http://localhost:${ACTIVE_PORT}/health" 2>/dev/null || echo "FAILED")
+echo -e "  ${GREEN}Local health:${NC}  $LOCAL"
+
+if [[ "$DRY_RUN" == false ]]; then
+  REMOTE=$(curl -sf "https://${FULL_DOMAIN}/health" 2>/dev/null || echo "check DNS/SSL")
+  echo -e "  ${GREEN}Remote health:${NC} $REMOTE"
+fi
+
+echo ""
+GIT_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+success "Update complete! Running commit: $GIT_COMMIT"
+[[ "$DRY_RUN" == true ]] && { echo ""; warn "Dry run — no changes made."; }


### PR DESCRIPTION
## Automated Deployment & Zero-Downtime Updates (Milestone 1)

This PR replaces the current multi-step manual setup process with a single-command deployment and introduces a zero-downtime update mechanism. It also adds an internal test tool for validating the API without needing an LMS.

### Problem

Deploying ByteGrader currently requires running three separate scripts (`setup-server.sh`, `deploy/deploy.sh`, `setup-ssl.sh`), manually editing environment variables across multiple files, and knowing the correct order of operations. This is error-prone and not repeatable — each deployment is effectively bespoke.

### Solution

Four files added to the repo root:

---

#### `config.yaml`
Single source of truth for all deployment variables. Replaces the interactive prompts in `setup-server.sh`. Operators edit one file — domain, subdomain, SSL email, API keys, IP whitelist, and grader image tags — and never touch anything else.

#### `deploy.sh`
Unified deployment script that consolidates `setup-server.sh`, `deploy/deploy.sh`, and `setup-ssl.sh` into a single command:

```bash
sudo bash deploy.sh
```

On a fresh Ubuntu 22.04/24.04 server with a domain pointed at it, this script:
- Installs all dependencies (Docker, nginx, certbot) if not present
- Creates the `bytegrader` system user
- Runs the existing internal `deploy/deploy.sh` to build and start containers
- Patches the generated `docker-compose.yaml` for Blue/Green support (`${APP_PORT}` and `${CONTAINER_NAME}` variable substitution)
- Generates the nginx config with SSL, CORS headers, and optional IP whitelisting
- Provisions a Let's Encrypt SSL certificate via certbot
- Validates DNS before attempting SSL to give a clear error if the domain isn't ready

Supports `--skip-ssl` for local/HTTP testing and `--skip-build` for config-only redeployments.

#### `update.sh`
Zero-downtime update script using a Blue/Green container swap:

```bash
sudo bash update.sh
```

- Pulls the latest git changes and rebuilds the Docker image
- Checks available RAM; if below 512MB (e.g. Raspberry Pi), automatically falls back to a graceful Stop-then-Start instead of Blue/Green
- Starts the new container on the staging port (8081), health checks it
- Swaps nginx upstream to the new container only after a successful health check
- Tears down the old container after a brief drain period
- Cleans up any leftover containers from previous failed attempts before starting
- Supports `--force-stop-start` and `--dry-run` flags

#### `test-tool/index.html`
Single-page internal validation tool. Open locally via VS Code Live Server or serve from nginx. No build step, no dependencies — just a browser.

- API key, username, and assignment fields with localStorage persistence
- ZIP file drag-and-drop or file picker
- Submits to `/submit`, then polls `/status` until the job completes
- Displays the raw JSON response with syntax highlighting at each step
- Renders the final score, pass/fail status, and grading feedback
- One-click `/health` and `/queue` checks

---

### Breaking Changes

None. The existing `deploy/deploy.sh`, `setup-server.sh`, and `setup-ssl.sh` are untouched. This PR adds new files alongside them.

### Testing

Validated end-to-end on a DigitalOcean Ubuntu 24.04 droplet:
- Fresh install via `deploy.sh` ✅
- SSL provisioning via Let's Encrypt ✅  
- Blue/Green update via `update.sh` with RAM check ✅
- Test tool submission, polling, and result display against `test-stub` and `make-c-add` graders ✅
- CORS working from `http://localhost:5500` (VS Code Live Server) ✅